### PR TITLE
Add user layout and user routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,11 +15,13 @@ import Calendar from "./pages/Calendar";
 import BasicTables from "./pages/Tables/BasicTables";
 import FormElements from "./pages/Forms/FormElements";
 import Blank from "./pages/Blank";
-import AppLayout from "./layout/AppLayout";
+import AdminLayout from "./layout/AdminLayout";
+import UserLayout from "./layout/UserLayout";
 import { ScrollToTop } from "./components/common/ScrollToTop";
 import Home from "./pages/Dashboard/Home";
 import UserInformationTable from "./pages/Tables/UserInformationTable";
 import StudenProcessTables from "./pages/Tables/StudenProcessTables";
+import UserHome from "./pages/User/Home";
 
 
 export default function App() {
@@ -28,9 +30,9 @@ export default function App() {
       <Router>
         <ScrollToTop />
         <Routes>
-          {/* Dashboard Layout */}
-          <Route element={<AppLayout />}>
-            <Route index path="/" element={<Home />} />
+          {/* Admin Layout */}
+          <Route path="/admin" element={<AdminLayout />}>
+            <Route index element={<Home />} />
 
             {/* Others Page */}
             <Route path="/profile" element={<UserProfiles />} />
@@ -56,7 +58,12 @@ export default function App() {
 
             {/* Charts */}
             <Route path="/line-chart" element={<LineChart />} />
-            <Route path="/bar-chart" element={<BarChart />} />
+          <Route path="/bar-chart" element={<BarChart />} />
+          </Route>
+
+          {/* User Layout */}
+          <Route path="/user" element={<UserLayout />}>
+            <Route index element={<UserHome />} />
           </Route>
 
           {/* Auth Layout */}

--- a/src/layout/AdminLayout.tsx
+++ b/src/layout/AdminLayout.tsx
@@ -27,7 +27,7 @@ const LayoutContent: React.FC = () => {
   );
 };
 
-const AppLayout: React.FC = () => {
+const AdminLayout: React.FC = () => {
   return (
     <SidebarProvider>
       <LayoutContent />
@@ -35,4 +35,4 @@ const AppLayout: React.FC = () => {
   );
 };
 
-export default AppLayout;
+export default AdminLayout;

--- a/src/layout/UserLayout.tsx
+++ b/src/layout/UserLayout.tsx
@@ -1,0 +1,16 @@
+import Header from "../components/header/Header";
+import { Outlet } from "react-router";
+
+const UserLayout: React.FC = () => {
+  const handleToggle = () => {};
+  return (
+    <div className="min-h-screen">
+      <Header onToggle={handleToggle} />
+      <div className="p-4 mx-auto max-w-(--breakpoint-2xl) md:p-6">
+        <Outlet />
+      </div>
+    </div>
+  );
+};
+
+export default UserLayout;

--- a/src/pages/User/Home.tsx
+++ b/src/pages/User/Home.tsx
@@ -1,0 +1,7 @@
+export default function UserHome() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">User Home</h1>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- rename `AppLayout` to `AdminLayout`
- add `UserLayout` with a simple header
- create a basic User home page
- route `/admin/*` through `AdminLayout`
- route `/user` through `UserLayout`

## Testing
- `npm run lint` *(fails: Unexpected any and other warnings)*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68463f81c6448333b34069bd430cf17c