### PR TITLE
Add admin management pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,22 @@ import Calendar from "./pages/Calendar";
 import BasicTables from "./pages/Tables/BasicTables";
 import FormElements from "./pages/Forms/FormElements";
 import Blank from "./pages/Blank";
+// Admin pages
+import FreezeLearner from "./pages/Admin/FreezeLearner";
+import UnfreezeLearner from "./pages/Admin/UnfreezeLearner";
+import SearchLearner from "./pages/Admin/SearchLearner";
+import ViewLearners from "./pages/Admin/ViewLearners";
+import DeleteMaterial from "./pages/Admin/DeleteMaterial";
+import ViolationReports from "./pages/Admin/ViolationReports";
+import LearnerXP from "./pages/Admin/LearnerXP";
+import LearnerLevels from "./pages/Admin/LearnerLevels";
+import SystemStats from "./pages/Admin/SystemStats";
+import AddGrammar from "./pages/Admin/AddGrammar";
+import DeleteGrammar from "./pages/Admin/DeleteGrammar";
+import EditGrammar from "./pages/Admin/EditGrammar";
+import AddVocabulary from "./pages/Admin/AddVocabulary";
+import DeleteVocabulary from "./pages/Admin/DeleteVocabulary";
+import EditVocabulary from "./pages/Admin/EditVocabulary";
 import AppLayout from "./layout/AppLayout";
 import { ScrollToTop } from "./components/common/ScrollToTop";
 import Home from "./pages/Dashboard/Home";
@@ -44,6 +60,23 @@ export default function App() {
             <Route path="/basic-tables" element={<BasicTables />} />
             <Route path="/userinfo-table" element={<UserInformationTable />} />
             <Route path="/studentprocess-table" element={<StudenProcessTables />} />
+
+            {/* Admin Learner Management */}
+            <Route path="/admin/freeze" element={<FreezeLearner />} />
+            <Route path="/admin/unfreeze" element={<UnfreezeLearner />} />
+            <Route path="/admin/search" element={<SearchLearner />} />
+            <Route path="/admin/learners" element={<ViewLearners />} />
+            <Route path="/admin/delete-material" element={<DeleteMaterial />} />
+            <Route path="/admin/reports" element={<ViolationReports />} />
+            <Route path="/admin/xp" element={<LearnerXP />} />
+            <Route path="/admin/levels" element={<LearnerLevels />} />
+            <Route path="/admin/stats" element={<SystemStats />} />
+            <Route path="/admin/grammar/add" element={<AddGrammar />} />
+            <Route path="/admin/grammar/delete" element={<DeleteGrammar />} />
+            <Route path="/admin/grammar/edit" element={<EditGrammar />} />
+            <Route path="/admin/vocabulary/add" element={<AddVocabulary />} />
+            <Route path="/admin/vocabulary/delete" element={<DeleteVocabulary />} />
+            <Route path="/admin/vocabulary/edit" element={<EditVocabulary />} />
 
 
             {/* Ui Elements */}

--- a/src/layout/AppSidebar.tsx
+++ b/src/layout/AppSidebar.tsx
@@ -31,12 +31,31 @@ const navItems: NavItem[] = [
   {
     icon: <UserIcon />,
     name: "Quản lí học viên ",
-    subItems: [{ name: "Quản lí thông tin học viên", path: "/userinfo-table", pro: false },
-              { name: "Quản lí tiến trình học tập học viên ", path: "/studentprocess-table", pro: false },
-              { name: "Quản lí tài liệu học viên ", path: "/", pro: false },
-              { name: "Quản lí báo cáo", path: "/", pro: false },
+    subItems: [
+      { name: "Danh sách học viên", path: "/admin/learners", pro: false },
+      { name: "Tìm kiếm học viên", path: "/admin/search", pro: false },
+      { name: "Đóng băng tài khoản", path: "/admin/freeze", pro: false },
+      { name: "Mở khóa tài khoản", path: "/admin/unfreeze", pro: false },
+      { name: "Tiến trình học tập", path: "/studentprocess-table", pro: false },
+      { name: "Điểm kinh nghiệm", path: "/admin/xp", pro: false },
+      { name: "Cấp độ học viên", path: "/admin/levels", pro: false },
+      { name: "Thống kê", path: "/admin/stats", pro: false },
+      { name: "Báo cáo vi phạm", path: "/admin/reports", pro: false },
+      { name: "Xóa tài liệu vi phạm", path: "/admin/delete-material", pro: false },
     ],
 
+  },
+  {
+    icon: <GridIcon />,
+    name: "Quản lí nội dung",
+    subItems: [
+      { name: "Thêm ngữ pháp", path: "/admin/grammar/add", pro: false },
+      { name: "Xóa ngữ pháp", path: "/admin/grammar/delete", pro: false },
+      { name: "Chỉnh sửa ngữ pháp", path: "/admin/grammar/edit", pro: false },
+      { name: "Thêm từ vựng", path: "/admin/vocabulary/add", pro: false },
+      { name: "Xóa từ vựng", path: "/admin/vocabulary/delete", pro: false },
+      { name: "Chỉnh sửa từ vựng", path: "/admin/vocabulary/edit", pro: false },
+    ],
   },
   {
     icon: <GridIcon />,

--- a/src/pages/Admin/AddGrammar.tsx
+++ b/src/pages/Admin/AddGrammar.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import axios from "axios";
+import PageMeta from "../../components/common/PageMeta";
+import PageBreadcrumb from "../../components/common/PageBreadCrumb";
+
+export default function AddGrammar() {
+  const [level, setLevel] = useState("");
+  const [content, setContent] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await axios.post("/api/admin/grammar", { level, content });
+      setMessage("Đã thêm ngữ pháp");
+      setContent("");
+    } catch (err) {
+      setMessage("Thêm thất bại");
+    }
+  };
+
+  return (
+    <>
+      <PageMeta title="Add Grammar" description="Add grammar" />
+      <PageBreadcrumb pageTitle="Thêm ngữ pháp" />
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
+        <input
+          type="text"
+          className="w-full rounded border px-3 py-2"
+          placeholder="Cấp độ"
+          value={level}
+          onChange={(e) => setLevel(e.target.value)}
+        />
+        <textarea
+          className="w-full rounded border px-3 py-2"
+          placeholder="Nội dung"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <button type="submit" className="rounded bg-blue-600 px-4 py-2 text-white">Thêm</button>
+        {message && <p className="text-sm text-gray-500">{message}</p>}
+      </form>
+    </>
+  );
+}

--- a/src/pages/Admin/AddVocabulary.tsx
+++ b/src/pages/Admin/AddVocabulary.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import axios from "axios";
+import PageMeta from "../../components/common/PageMeta";
+import PageBreadcrumb from "../../components/common/PageBreadCrumb";
+
+export default function AddVocabulary() {
+  const [level, setLevel] = useState("");
+  const [word, setWord] = useState("");
+  const [meaning, setMeaning] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await axios.post("/api/admin/vocabulary", { level, word, meaning });
+      setMessage("Đã thêm từ vựng");
+      setWord("");
+      setMeaning("");
+    } catch (err) {
+      setMessage("Thêm thất bại");
+    }
+  };
+
+  return (
+    <>
+      <PageMeta title="Add Vocabulary" description="Add vocabulary" />
+      <PageBreadcrumb pageTitle="Thêm từ vựng" />
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
+        <input
+          type="text"
+          className="w-full rounded border px-3 py-2"
+          placeholder="Cấp độ"
+          value={level}
+          onChange={(e) => setLevel(e.target.value)}
+        />
+        <input
+          type="text"
+          className="w-full rounded border px-3 py-2"
+          placeholder="Từ vựng"
+          value={word}
+          onChange={(e) => setWord(e.target.value)}
+        />
+        <input
+          type="text"
+          className="w-full rounded border px-3 py-2"
+          placeholder="Nghĩa"
+          value={meaning}
+          onChange={(e) => setMeaning(e.target.value)}
+        />
+        <button type="submit" className="rounded bg-blue-600 px-4 py-2 text-white">Thêm</button>
+        {message && <p className="text-sm text-gray-500">{message}</p>}
+      </form>
+    </>
+  );
+}

--- a/src/pages/Admin/DeleteGrammar.tsx
+++ b/src/pages/Admin/DeleteGrammar.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import axios from "axios";
+import PageMeta from "../../components/common/PageMeta";
+import PageBreadcrumb from "../../components/common/PageBreadCrumb";
+
+export default function DeleteGrammar() {
+  const [id, setId] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await axios.delete(`/api/admin/grammar/${id}`);
+      setMessage("Đã xóa ngữ pháp");
+    } catch (err) {
+      setMessage("Xóa thất bại");
+    }
+  };
+
+  return (
+    <>
+      <PageMeta title="Delete Grammar" description="Delete grammar" />
+      <PageBreadcrumb pageTitle="Xóa ngữ pháp" />
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
+        <input
+          type="text"
+          className="w-full rounded border px-3 py-2"
+          placeholder="ID ngữ pháp"
+          value={id}
+          onChange={(e) => setId(e.target.value)}
+        />
+        <button type="submit" className="rounded bg-red-600 px-4 py-2 text-white">Xóa</button>
+        {message && <p className="text-sm text-gray-500">{message}</p>}
+      </form>
+    </>
+  );
+}

--- a/src/pages/Admin/DeleteMaterial.tsx
+++ b/src/pages/Admin/DeleteMaterial.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import axios from "axios";
+import PageMeta from "../../components/common/PageMeta";
+import PageBreadcrumb from "../../components/common/PageBreadCrumb";
+
+export default function DeleteMaterial() {
+  const [materialId, setMaterialId] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleDelete = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await axios.delete(`/api/admin/materials/${materialId}`);
+      setMessage("Đã xóa tài liệu");
+    } catch (err) {
+      setMessage("Xóa thất bại");
+    }
+  };
+
+  return (
+    <>
+      <PageMeta title="Delete Material" description="Delete learning material" />
+      <PageBreadcrumb pageTitle="Xóa tài liệu vi phạm" />
+      <form onSubmit={handleDelete} className="space-y-4 max-w-sm">
+        <input
+          type="text"
+          className="w-full rounded border px-3 py-2"
+          placeholder="ID tài liệu"
+          value={materialId}
+          onChange={(e) => setMaterialId(e.target.value)}
+        />
+        <button type="submit" className="rounded bg-red-600 px-4 py-2 text-white">
+          Xóa
+        </button>
+        {message && <p className="text-sm text-gray-500">{message}</p>}
+      </form>
+    </>
+  );
+}

--- a/src/pages/Admin/DeleteVocabulary.tsx
+++ b/src/pages/Admin/DeleteVocabulary.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import axios from "axios";
+import PageMeta from "../../components/common/PageMeta";
+import PageBreadcrumb from "../../components/common/PageBreadCrumb";
+
+export default function DeleteVocabulary() {
+  const [id, setId] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await axios.delete(`/api/admin/vocabulary/${id}`);
+      setMessage("Đã xóa từ vựng");
+    } catch (err) {
+      setMessage("Xóa thất bại");
+    }
+  };
+
+  return (
+    <>
+      <PageMeta title="Delete Vocabulary" description="Delete vocabulary" />
+      <PageBreadcrumb pageTitle="Xóa từ vựng" />
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
+        <input
+          type="text"
+          className="w-full rounded border px-3 py-2"
+          placeholder="ID từ vựng"
+          value={id}
+          onChange={(e) => setId(e.target.value)}
+        />
+        <button type="submit" className="rounded bg-red-600 px-4 py-2 text-white">Xóa</button>
+        {message && <p className="text-sm text-gray-500">{message}</p>}
+      </form>
+    </>
+  );
+}

--- a/src/pages/Admin/EditGrammar.tsx
+++ b/src/pages/Admin/EditGrammar.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import axios from "axios";
+import PageMeta from "../../components/common/PageMeta";
+import PageBreadcrumb from "../../components/common/PageBreadCrumb";
+
+export default function EditGrammar() {
+  const [id, setId] = useState("");
+  const [content, setContent] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await axios.put(`/api/admin/grammar/${id}`, { content });
+      setMessage("Đã cập nhật");
+    } catch (err) {
+      setMessage("Cập nhật thất bại");
+    }
+  };
+
+  return (
+    <>
+      <PageMeta title="Edit Grammar" description="Edit grammar" />
+      <PageBreadcrumb pageTitle="Chỉnh sửa ngữ pháp" />
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
+        <input
+          type="text"
+          className="w-full rounded border px-3 py-2"
+          placeholder="ID ngữ pháp"
+          value={id}
+          onChange={(e) => setId(e.target.value)}
+        />
+        <textarea
+          className="w-full rounded border px-3 py-2"
+          placeholder="Nội dung"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <button type="submit" className="rounded bg-blue-600 px-4 py-2 text-white">Lưu</button>
+        {message && <p className="text-sm text-gray-500">{message}</p>}
+      </form>
+    </>
+  );
+}

--- a/src/pages/Admin/EditVocabulary.tsx
+++ b/src/pages/Admin/EditVocabulary.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import axios from "axios";
+import PageMeta from "../../components/common/PageMeta";
+import PageBreadcrumb from "../../components/common/PageBreadCrumb";
+
+export default function EditVocabulary() {
+  const [id, setId] = useState("");
+  const [meaning, setMeaning] = useState("");
+  const [pronunciation, setPronunciation] = useState("");
+  const [example, setExample] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await axios.put(`/api/admin/vocabulary/${id}`, {
+        meaning,
+        pronunciation,
+        example,
+      });
+      setMessage("Đã cập nhật");
+    } catch (err) {
+      setMessage("Cập nhật thất bại");
+    }
+  };
+
+  return (
+    <>
+      <PageMeta title="Edit Vocabulary" description="Edit vocabulary" />
+      <PageBreadcrumb pageTitle="Chỉnh sửa từ vựng" />
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
+        <input
+          type="text"
+          className="w-full rounded border px-3 py-2"
+          placeholder="ID từ vựng"
+          value={id}
+          onChange={(e) => setId(e.target.value)}
+        />
+        <input
+          type="text"
+          className="w-full rounded border px-3 py-2"
+          placeholder="Nghĩa"
+          value={meaning}
+          onChange={(e) => setMeaning(e.target.value)}
+        />
+        <input
+          type="text"
+          className="w-full rounded border px-3 py-2"
+          placeholder="Phát âm"
+          value={pronunciation}
+          onChange={(e) => setPronunciation(e.target.value)}
+        />
+        <textarea
+          className="w-full rounded border px-3 py-2"
+          placeholder="Ví dụ"
+          value={example}
+          onChange={(e) => setExample(e.target.value)}
+        />
+        <button type="submit" className="rounded bg-blue-600 px-4 py-2 text-white">Lưu</button>
+        {message && <p className="text-sm text-gray-500">{message}</p>}
+      </form>
+    </>
+  );
+}

--- a/src/pages/Admin/FreezeLearner.tsx
+++ b/src/pages/Admin/FreezeLearner.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import axios from "axios";
+import PageBreadcrumb from "../../components/common/PageBreadCrumb";
+import PageMeta from "../../components/common/PageMeta";
+
+export default function FreezeLearner() {
+  const [identifier, setIdentifier] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await axios.post("/api/admin/learners/freeze", { identifier });
+      setMessage("Tài khoản đã được đóng băng");
+    } catch (err) {
+      setMessage("Đóng băng thất bại");
+    }
+  };
+
+  return (
+    <>
+      <PageMeta title="Freeze Learner" description="Block learner account" />
+      <PageBreadcrumb pageTitle="Đóng băng tài khoản" />
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
+        <input
+          type="text"
+          className="w-full rounded border px-3 py-2"
+          placeholder="Email hoặc ID"
+          value={identifier}
+          onChange={(e) => setIdentifier(e.target.value)}
+        />
+        <button type="submit" className="rounded bg-blue-600 px-4 py-2 text-white">
+          Đóng băng
+        </button>
+        {message && <p className="text-sm text-gray-500">{message}</p>}
+      </form>
+    </>
+  );
+}

--- a/src/pages/Admin/LearnerLevels.tsx
+++ b/src/pages/Admin/LearnerLevels.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import PageMeta from "../../components/common/PageMeta";
+import PageBreadcrumb from "../../components/common/PageBreadCrumb";
+import { Table, TableBody, TableCell, TableHeader, TableRow } from "../../components/ui/table";
+
+interface Level {
+  id: number;
+  name: string;
+  requiredXP: number;
+}
+
+export default function LearnerLevels() {
+  const [levels, setLevels] = useState<Level[]>([]);
+
+  useEffect(() => {
+    axios.get("/api/admin/levels").then((res) => setLevels(res.data));
+  }, []);
+
+  return (
+    <>
+      <PageMeta title="Learner Levels" description="Levels" />
+      <PageBreadcrumb pageTitle="Các cấp độ" />
+      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-white/[0.05] dark:bg-white/[0.03]">
+        <div className="max-w-full overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableCell isHeader className="px-5 py-3 text-theme-xs font-medium text-gray-500 dark:text-gray-400">Cấp độ</TableCell>
+                <TableCell isHeader className="px-5 py-3 text-theme-xs font-medium text-gray-500 dark:text-gray-400">XP yêu cầu</TableCell>
+              </TableRow>
+            </TableHeader>
+            <TableBody className="divide-y divide-gray-100 dark:divide-white/[0.05]">
+              {levels.map((lv) => (
+                <TableRow key={lv.id} className="hover:bg-gray-50 dark:hover:bg-white/5">
+                  <TableCell className="px-5 py-3 text-theme-sm text-gray-800 dark:text-white/90">{lv.name}</TableCell>
+                  <TableCell className="px-5 py-3 text-theme-sm text-gray-500 dark:text-gray-400">{lv.requiredXP}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/pages/Admin/LearnerXP.tsx
+++ b/src/pages/Admin/LearnerXP.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import PageMeta from "../../components/common/PageMeta";
+import PageBreadcrumb from "../../components/common/PageBreadCrumb";
+import { Table, TableBody, TableCell, TableHeader, TableRow } from "../../components/ui/table";
+
+interface XPRow {
+  userId: number;
+  fullName: string;
+  xp: number;
+  level: string;
+}
+
+export default function LearnerXP() {
+  const [data, setData] = useState<XPRow[]>([]);
+
+  useEffect(() => {
+    axios.get("/api/admin/learners/xp").then((res) => setData(res.data));
+  }, []);
+
+  return (
+    <>
+      <PageMeta title="Learner XP" description="Experience points" />
+      <PageBreadcrumb pageTitle="Điểm kinh nghiệm học viên" />
+      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-white/[0.05] dark:bg-white/[0.03]">
+        <div className="max-w-full overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableCell isHeader className="px-5 py-3 text-theme-xs font-medium text-gray-500 dark:text-gray-400">Học viên</TableCell>
+                <TableCell isHeader className="px-5 py-3 text-theme-xs font-medium text-gray-500 dark:text-gray-400">XP</TableCell>
+                <TableCell isHeader className="px-5 py-3 text-theme-xs font-medium text-gray-500 dark:text-gray-400">Cấp</TableCell>
+              </TableRow>
+            </TableHeader>
+            <TableBody className="divide-y divide-gray-100 dark:divide-white/[0.05]">
+              {data.map((row) => (
+                <TableRow key={row.userId} className="hover:bg-gray-50 dark:hover:bg-white/5">
+                  <TableCell className="px-5 py-3 text-theme-sm text-gray-800 dark:text-white/90">{row.fullName}</TableCell>
+                  <TableCell className="px-5 py-3 text-theme-sm text-gray-500 dark:text-gray-400">{row.xp}</TableCell>
+                  <TableCell className="px-5 py-3 text-theme-sm text-gray-500 dark:text-gray-400">{row.level}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/pages/Admin/SearchLearner.tsx
+++ b/src/pages/Admin/SearchLearner.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import axios from "axios";
+import PageBreadcrumb from "../../components/common/PageBreadCrumb";
+import PageMeta from "../../components/common/PageMeta";
+
+interface Learner {
+  userId: number;
+  fullName: string;
+  email: string;
+}
+
+export default function SearchLearner() {
+  const [keyword, setKeyword] = useState("");
+  const [results, setResults] = useState<Learner[]>([]);
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await axios.get(`/api/admin/learners/search?keyword=${keyword}`);
+    setResults(res.data);
+  };
+
+  return (
+    <>
+      <PageMeta title="Search Learner" description="Search learner" />
+      <PageBreadcrumb pageTitle="Tìm kiếm học viên" />
+      <form onSubmit={handleSearch} className="space-y-4 max-w-sm mb-6">
+        <input
+          type="text"
+          className="w-full rounded border px-3 py-2"
+          placeholder="Tên hoặc Email"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+        />
+        <button type="submit" className="rounded bg-blue-600 px-4 py-2 text-white">
+          Tìm kiếm
+        </button>
+      </form>
+      {results.length > 0 && (
+        <ul className="space-y-2">
+          {results.map((l) => (
+            <li key={l.userId} className="border-b pb-1">
+              {l.fullName} ({l.email})
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/src/pages/Admin/SystemStats.tsx
+++ b/src/pages/Admin/SystemStats.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import PageMeta from "../../components/common/PageMeta";
+import PageBreadcrumb from "../../components/common/PageBreadCrumb";
+
+interface Stats {
+  totalUsers: number;
+  newSignups: number;
+  inactiveUsers: number;
+}
+
+export default function SystemStats() {
+  const [stats, setStats] = useState<Stats | null>(null);
+
+  useEffect(() => {
+    axios.get("/api/admin/stats").then((res) => setStats(res.data));
+  }, []);
+
+  return (
+    <>
+      <PageMeta title="Statistics" description="System stats" />
+      <PageBreadcrumb pageTitle="Thống kê hệ thống" />
+      {stats ? (
+        <ul className="space-y-2 text-theme-sm">
+          <li>Tổng người dùng: {stats.totalUsers}</li>
+          <li>Đăng ký mới: {stats.newSignups}</li>
+          <li>Người dùng không hoạt động: {stats.inactiveUsers}</li>
+        </ul>
+      ) : (
+        <p>Đang tải...</p>
+      )}
+    </>
+  );
+}

--- a/src/pages/Admin/UnfreezeLearner.tsx
+++ b/src/pages/Admin/UnfreezeLearner.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import axios from "axios";
+import PageBreadcrumb from "../../components/common/PageBreadCrumb";
+import PageMeta from "../../components/common/PageMeta";
+
+export default function UnfreezeLearner() {
+  const [identifier, setIdentifier] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await axios.post("/api/admin/learners/unfreeze", { identifier });
+      setMessage("Tài khoản đã được mở khóa");
+    } catch (err) {
+      setMessage("Mở khóa thất bại");
+    }
+  };
+
+  return (
+    <>
+      <PageMeta title="Unfreeze Learner" description="Restore learner" />
+      <PageBreadcrumb pageTitle="Mở khóa tài khoản" />
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
+        <input
+          type="text"
+          className="w-full rounded border px-3 py-2"
+          placeholder="Email hoặc ID"
+          value={identifier}
+          onChange={(e) => setIdentifier(e.target.value)}
+        />
+        <button type="submit" className="rounded bg-blue-600 px-4 py-2 text-white">
+          Mở khóa
+        </button>
+        {message && <p className="text-sm text-gray-500">{message}</p>}
+      </form>
+    </>
+  );
+}

--- a/src/pages/Admin/ViewLearners.tsx
+++ b/src/pages/Admin/ViewLearners.tsx
@@ -1,0 +1,18 @@
+import PageMeta from "../../components/common/PageMeta";
+import PageBreadcrumb from "../../components/common/PageBreadCrumb";
+import ComponentCard from "../../components/common/ComponentCard";
+import UserInfoOne from "../../components/tables/BasicTables/UserInfoOne";
+
+export default function ViewLearners() {
+  return (
+    <>
+      <PageMeta title="Learner List" description="View all learners" />
+      <PageBreadcrumb pageTitle="Danh sách học viên" />
+      <div className="space-y-6">
+        <ComponentCard title="Bảng học viên">
+          <UserInfoOne />
+        </ComponentCard>
+      </div>
+    </>
+  );
+}

--- a/src/pages/Admin/ViolationReports.tsx
+++ b/src/pages/Admin/ViolationReports.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import PageMeta from "../../components/common/PageMeta";
+import PageBreadcrumb from "../../components/common/PageBreadCrumb";
+import { Table, TableBody, TableCell, TableHeader, TableRow } from "../../components/ui/table";
+
+interface Report {
+  id: number;
+  reporter: string;
+  content: string;
+}
+
+export default function ViolationReports() {
+  const [reports, setReports] = useState<Report[]>([]);
+
+  useEffect(() => {
+    axios.get("/api/admin/reports").then((res) => setReports(res.data));
+  }, []);
+
+  return (
+    <>
+      <PageMeta title="Violation Reports" description="User reports" />
+      <PageBreadcrumb pageTitle="Báo cáo vi phạm" />
+      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-white/[0.05] dark:bg-white/[0.03]">
+        <div className="max-w-full overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableCell isHeader className="px-5 py-3 text-theme-xs font-medium text-gray-500 dark:text-gray-400">Người báo cáo</TableCell>
+                <TableCell isHeader className="px-5 py-3 text-theme-xs font-medium text-gray-500 dark:text-gray-400">Nội dung</TableCell>
+              </TableRow>
+            </TableHeader>
+            <TableBody className="divide-y divide-gray-100 dark:divide-white/[0.05]">
+              {reports.map((r) => (
+                <TableRow key={r.id} className="hover:bg-gray-50 dark:hover:bg-white/5">
+                  <TableCell className="px-5 py-3 text-theme-sm text-gray-800 dark:text-white/90">{r.reporter}</TableCell>
+                  <TableCell className="px-5 py-3 text-theme-sm text-gray-500 dark:text-gray-400">{r.content}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce admin pages for managing learners, content and stats
- wire up routes in `App.tsx`
- extend sidebar navigation with new admin links

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: multiple module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846518ed828833391a638165fd1dd8c